### PR TITLE
Optimized memory usage while building url path

### DIFF
--- a/src/gitter.rs
+++ b/src/gitter.rs
@@ -47,7 +47,7 @@ impl<'a> Gitter<'a> {
 
     /// Returns the current user
     pub fn get_user(&self) -> ApiResult<User> {
-        let full_url = self.api_base_url.to_string() + "user";
+        let full_url = format!("{}user", self.api_base_url);
         match self.get::<&str, Vec<User>>(&full_url) {
             Ok(users) => {
                 if !users.is_empty() {
@@ -65,7 +65,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/rooms";
+        let full_url = format!("{}user/{}/rooms", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -75,8 +75,7 @@ impl<'a> Gitter<'a> {
         U: AsRef<str>,
         R: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/rooms"
-            + room_id.as_ref() + "/unreadItems";
+        let full_url = format!("{}user/{}/rooms/{}/unreadItems", self.api_base_url, user_id.as_ref(), room_id.as_ref());
         self.get(&full_url)
     }
 
@@ -91,15 +90,14 @@ impl<'a> Gitter<'a> {
         U: AsRef<str>,
         R: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/rooms"
-            + room_id.as_ref() + "/unreadItems";
+        let full_url = format!("{}user/{}/rooms/{}/unreadItems", self.api_base_url, user_id.as_ref(), room_id.as_ref());
         let unread_items = UnreadItems::from_msg_ids(message_ids);
         self.post(&full_url, &unread_items)
     }
 
     /// Returns a list of rooms the current user is in
     pub fn get_rooms(&self) -> ApiResult<Vec<Room>> {
-        let full_url = self.api_base_url.to_string() + "rooms";
+        let full_url = format!("{}rooms", self.api_base_url);
         self.get(&full_url)
     }
 
@@ -108,7 +106,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/orgs";
+        let full_url = format!("{}user/{}/orgs", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -117,7 +115,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/repos";
+        let full_url = format!("{}/user/{}/repos", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -126,7 +124,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/channels";
+        let full_url = format!("{}user/{}/channels", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -135,7 +133,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref() + "/users";
+        let full_url = format!("{}rooms/{}/users", self.api_base_url, room_id.as_ref());
         self.get(&full_url)
     }
 
@@ -144,7 +142,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref();
+        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
         self.get(&full_url)
     }
 
@@ -154,8 +152,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let mut full_url =
-            self.api_base_url.to_string() + "rooms/" + room_id.as_ref() + "/chatMessages";
+        let mut full_url = format!("{}rooms/{}/chatMessages", self.api_base_url, room_id.as_ref());
 
         if let Some(p) = params {
             full_url.push_str("?");
@@ -171,9 +168,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         M: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref()
-            + "/chatMessages/" + message_id.as_ref();
-
+        let full_url = format!("{}rooms/{}/chatMessages/{}", self.api_base_url, room_id.as_ref(), message_id.as_ref());
         self.get(&full_url)
     }
 
@@ -183,10 +178,9 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url =
-            self.api_base_url.to_string() + "rooms/" + room_id.as_ref() + "/chatMessages";
+        let full_url = format!("{}rooms/{}/chatMessages", self.api_base_url, room_id.as_ref());
         let msg = OutMessage {
-            text: text.as_ref().to_string(),
+            text: text.as_ref()
         };
 
         self.post(&full_url, &msg)
@@ -199,10 +193,9 @@ impl<'a> Gitter<'a> {
         M: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref()
-            + "/chatMessages/" + msg_id.as_ref();
+        let full_url = format!("{}rooms/{}/chatMessages/{}", self.api_base_url, room_id.as_ref(), msg_id.as_ref());
         let msg = OutMessage {
-            text: text.as_ref().to_string(),
+            text: text.as_ref()
         };
 
         self.put(&full_url, &msg)
@@ -214,7 +207,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         U: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "user/" + user_id.as_ref() + "/rooms";
+        let full_url = format!("{}user/{}/rooms", self.api_base_url, user_id.as_ref());
         let room = JoinRoom::from_id(room_id);
 
         self.post(&full_url, &room)
@@ -225,7 +218,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms";
+        let full_url = format!("{}rooms", self.api_base_url);
         let room = JoinRoom::from_uri(uri);
 
         self.post(&full_url, &room)
@@ -237,7 +230,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref();
+        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
         let room = UpdateRoom::from_topic(topic);
 
         self.post(&full_url, &room)
@@ -248,7 +241,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref();
+        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
         let room = UpdateRoom::from_noindex(noindex.into());
 
         self.post(&full_url, &room)
@@ -260,7 +253,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref();
+        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
         let room = UpdateRoom::from_tags(tags);
 
         self.post(&full_url, &room)
@@ -272,8 +265,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         U: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref() + "/users/"
-            + user_id.as_ref();
+        let full_url = format!("{}rooms/{}/users/{}", self.api_base_url, room_id.as_ref(), user_id.as_ref());
 
         self.delete(&full_url)
     }
@@ -283,7 +275,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "rooms/" + room_id.as_ref();
+        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
 
         self.delete(&full_url)
     }
@@ -294,8 +286,7 @@ impl<'a> Gitter<'a> {
         S: AsRef<str>,
     {
         let query = &[("q", room.as_ref())];
-        let full_url =
-            self.api_base_url.to_string() + "rooms?" + &serde_urlencoded::to_string(query).unwrap();
+        let full_url = format!("{}rooms?{}", self.api_base_url, &serde_urlencoded::to_string(query).unwrap());
 
         self.get(&full_url)
     }
@@ -316,7 +307,8 @@ impl<'a> Gitter<'a> {
 
     /// Returns a list of groups the current user is in
     pub fn get_groups(&self) -> ApiResult<Vec<Group>> {
-        let full_url = self.api_base_url.to_string() + "groups";
+        let full_url = format!("{}groups", self.api_base_url);
+
         self.get(&full_url)
     }
 
@@ -325,7 +317,8 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = self.api_base_url.to_string() + "groups/" + group_id.as_ref() + "/rooms";
+        let full_url = format!("{}groups/{}/rooms", self.api_base_url, group_id.as_ref());
+
         self.get(&full_url)
     }
 

--- a/src/gitter.rs
+++ b/src/gitter.rs
@@ -15,7 +15,7 @@ pub struct Gitter<'a> {
     client: Client,
 }
 
-const API_BASE_URL: &str = "https://api.gitter.im/v1/";
+const API_BASE_URL: &str = "https://api.gitter.im/v1";
 
 #[derive(Debug)]
 pub enum ApiError {
@@ -47,7 +47,7 @@ impl<'a> Gitter<'a> {
 
     /// Returns the current user
     pub fn get_user(&self) -> ApiResult<User> {
-        let full_url = format!("{}user", self.api_base_url);
+        let full_url = format!("{}/user", self.api_base_url);
         match self.get::<&str, Vec<User>>(&full_url) {
             Ok(users) => {
                 if !users.is_empty() {
@@ -65,7 +65,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}user/{}/rooms", self.api_base_url, user_id.as_ref());
+        let full_url = format!("{}/user/{}/rooms", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -75,7 +75,7 @@ impl<'a> Gitter<'a> {
         U: AsRef<str>,
         R: AsRef<str>,
     {
-        let full_url = format!("{}user/{}/rooms/{}/unreadItems", self.api_base_url, user_id.as_ref(), room_id.as_ref());
+        let full_url = format!("{}/user/{}/rooms/{}/unreadItems", self.api_base_url, user_id.as_ref(), room_id.as_ref());
         self.get(&full_url)
     }
 
@@ -90,14 +90,14 @@ impl<'a> Gitter<'a> {
         U: AsRef<str>,
         R: AsRef<str>,
     {
-        let full_url = format!("{}user/{}/rooms/{}/unreadItems", self.api_base_url, user_id.as_ref(), room_id.as_ref());
+        let full_url = format!("{}/user/{}/rooms/{}/unreadItems", self.api_base_url, user_id.as_ref(), room_id.as_ref());
         let unread_items = UnreadItems::from_msg_ids(message_ids);
         self.post(&full_url, &unread_items)
     }
 
     /// Returns a list of rooms the current user is in
     pub fn get_rooms(&self) -> ApiResult<Vec<Room>> {
-        let full_url = format!("{}rooms", self.api_base_url);
+        let full_url = format!("{}/rooms", self.api_base_url);
         self.get(&full_url)
     }
 
@@ -106,7 +106,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}user/{}/orgs", self.api_base_url, user_id.as_ref());
+        let full_url = format!("{}/user/{}/orgs", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -124,7 +124,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}user/{}/channels", self.api_base_url, user_id.as_ref());
+        let full_url = format!("{}/user/{}/channels", self.api_base_url, user_id.as_ref());
         self.get(&full_url)
     }
 
@@ -133,7 +133,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}/users", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}/users", self.api_base_url, room_id.as_ref());
         self.get(&full_url)
     }
 
@@ -142,7 +142,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}", self.api_base_url, room_id.as_ref());
         self.get(&full_url)
     }
 
@@ -152,7 +152,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let mut full_url = format!("{}rooms/{}/chatMessages", self.api_base_url, room_id.as_ref());
+        let mut full_url = format!("{}/rooms/{}/chatMessages", self.api_base_url, room_id.as_ref());
 
         if let Some(p) = params {
             full_url.push_str("?");
@@ -168,7 +168,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         M: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}/chatMessages/{}", self.api_base_url, room_id.as_ref(), message_id.as_ref());
+        let full_url = format!("{}/rooms/{}/chatMessages/{}", self.api_base_url, room_id.as_ref(), message_id.as_ref());
         self.get(&full_url)
     }
 
@@ -178,7 +178,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}/chatMessages", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}/chatMessages", self.api_base_url, room_id.as_ref());
         let msg = OutMessage {
             text: text.as_ref()
         };
@@ -193,7 +193,7 @@ impl<'a> Gitter<'a> {
         M: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}/chatMessages/{}", self.api_base_url, room_id.as_ref(), msg_id.as_ref());
+        let full_url = format!("{}/rooms/{}/chatMessages/{}", self.api_base_url, room_id.as_ref(), msg_id.as_ref());
         let msg = OutMessage {
             text: text.as_ref()
         };
@@ -207,7 +207,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         U: AsRef<str>,
     {
-        let full_url = format!("{}user/{}/rooms", self.api_base_url, user_id.as_ref());
+        let full_url = format!("{}/user/{}/rooms", self.api_base_url, user_id.as_ref());
         let room = JoinRoom::from_id(room_id);
 
         self.post(&full_url, &room)
@@ -218,7 +218,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}rooms", self.api_base_url);
+        let full_url = format!("{}/rooms", self.api_base_url);
         let room = JoinRoom::from_uri(uri);
 
         self.post(&full_url, &room)
@@ -230,7 +230,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}", self.api_base_url, room_id.as_ref());
         let room = UpdateRoom::from_topic(topic);
 
         self.post(&full_url, &room)
@@ -241,7 +241,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}", self.api_base_url, room_id.as_ref());
         let room = UpdateRoom::from_noindex(noindex.into());
 
         self.post(&full_url, &room)
@@ -253,7 +253,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         T: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}", self.api_base_url, room_id.as_ref());
         let room = UpdateRoom::from_tags(tags);
 
         self.post(&full_url, &room)
@@ -265,7 +265,7 @@ impl<'a> Gitter<'a> {
         R: AsRef<str>,
         U: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}/users/{}", self.api_base_url, room_id.as_ref(), user_id.as_ref());
+        let full_url = format!("{}/rooms/{}/users/{}", self.api_base_url, room_id.as_ref(), user_id.as_ref());
 
         self.delete(&full_url)
     }
@@ -275,7 +275,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}rooms/{}", self.api_base_url, room_id.as_ref());
+        let full_url = format!("{}/rooms/{}", self.api_base_url, room_id.as_ref());
 
         self.delete(&full_url)
     }
@@ -286,7 +286,7 @@ impl<'a> Gitter<'a> {
         S: AsRef<str>,
     {
         let query = &[("q", room.as_ref())];
-        let full_url = format!("{}rooms?{}", self.api_base_url, &serde_urlencoded::to_string(query).unwrap());
+        let full_url = format!("{}/rooms?{}", self.api_base_url, &serde_urlencoded::to_string(query).unwrap());
 
         self.get(&full_url)
     }
@@ -307,7 +307,7 @@ impl<'a> Gitter<'a> {
 
     /// Returns a list of groups the current user is in
     pub fn get_groups(&self) -> ApiResult<Vec<Group>> {
-        let full_url = format!("{}groups", self.api_base_url);
+        let full_url = format!("{}/groups", self.api_base_url);
 
         self.get(&full_url)
     }
@@ -317,7 +317,7 @@ impl<'a> Gitter<'a> {
     where
         S: AsRef<str>,
     {
-        let full_url = format!("{}groups/{}/rooms", self.api_base_url, group_id.as_ref());
+        let full_url = format!("{}/groups/{}/rooms", self.api_base_url, group_id.as_ref());
 
         self.get(&full_url)
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -240,9 +240,9 @@ pub struct Message {
 
 /// Send message request model
 #[derive(Serialize, Debug)]
-pub struct OutMessage {
+pub struct OutMessage<'a> {
     /// Original message in plain-text/markdown
-    pub text: String,
+    pub text: &'a str,
 }
 
 /// Mention holds data about mentioned user in the message

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,8 @@ extern crate serde_json;
 use gitter::*;
 
 fn get_gitter_api<'a>() -> Gitter<'a> {
-    let token = std::env::var("GITTER_BOT_TOKEN").unwrap();
+    let token = std::env::var("GITTER_BOT_TOKEN")
+        .unwrap_or("GITTER_TOKEN_VALUE".into());
     Gitter::new(token).unwrap()
 }
 
@@ -28,17 +29,12 @@ fn deserialize_user() {
 #[test]
 fn serialize_out_message() {
     let out_msg = OutMessage {
-        text: "test `message` from @shmutalov".to_string(),
+        text: "test `message` from @shmutalov"
     };
     let out_msg_expected = "{\"text\":\"test `message` from @shmutalov\"}";
     let out_msg_json = serde_json::to_string(&out_msg).unwrap();
 
     assert_eq!(&out_msg_expected, &out_msg_json);
-}
-
-#[test]
-fn api_init() {
-    Gitter::new("asbcasadasd").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
- Used `format!` macro, because it uses `String::with_capacity` to create destination string.
- `format!` macro allow to call `Display` trait implementation on `Cow` and if it contains borrowed value, it doesn't allocate new string.

